### PR TITLE
Honor PGHOST env var in local.php

### DIFF
--- a/nominatim/local.php
+++ b/nominatim/local.php
@@ -1,6 +1,6 @@
 <?php
  // General settings
- @define('CONST_Database_DSN', 'pgsql://nominatim@postgis:5432/nominatim'); // <driver>://<username>:<password>@<host>:<port>/<database>
+ @define('CONST_Database_DSN', 'pgsql://nominatim@' . getenv('PGHOST') . ':5432/nominatim'); // <driver>://<username>:<password>@<host>:<port>/<database>
  @define('CONST_Website_BaseURL', '/');
  // Software versions
  @define('CONST_Postgresql_Version', '9.4');


### PR DESCRIPTION
We use PGHOST environment variable everywhere except `local.php` which is the main point of Nominatim configuration. Let's be consistent and use it there as well.